### PR TITLE
Add the actual scripts to sensu-plugins-sidekiq

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,73 @@
+PATH
+  remote: .
+  specs:
+    sensu-plugins-sidekiq (0.0.1.alpha.1)
+      sensu-plugin (= 1.1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.0.0)
+    codeclimate-test-reporter (0.4.7)
+      simplecov (>= 0.7.1, < 1.0.0)
+    coderay (1.1.0)
+    diff-lcs (1.2.5)
+    docile (1.1.5)
+    github-markup (1.3.3)
+    json (1.8.2)
+    method_source (0.8.2)
+    mixlib-cli (1.5.0)
+    parser (2.1.9)
+      ast (>= 1.1, < 3.0)
+      slop (~> 3.4, >= 3.4.5)
+    powerpack (0.0.9)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    rainbow (1.99.2)
+    rake (10.4.2)
+    redcarpet (3.2.3)
+    rspec (3.2.0)
+      rspec-core (~> 3.2.0)
+      rspec-expectations (~> 3.2.0)
+      rspec-mocks (~> 3.2.0)
+    rspec-core (3.2.3)
+      rspec-support (~> 3.2.0)
+    rspec-expectations (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-mocks (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-support (3.2.2)
+    rubocop (0.17.0)
+      json (~> 1.8)
+      parser (~> 2.1.3)
+      powerpack (~> 0.0.6)
+      rainbow (~> 1.99.1)
+    sensu-plugin (1.1.0)
+      json
+      mixlib-cli (>= 1.1.0)
+    simplecov (0.10.0)
+      docile (~> 1.1.0)
+      json (~> 1.8)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
+    slop (3.6.0)
+    yard (0.8.7.6)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 1.7)
+  codeclimate-test-reporter (~> 0.4)
+  github-markup (~> 1.3)
+  pry (~> 0.10)
+  rake (~> 10.0)
+  redcarpet (~> 3.2)
+  rspec (~> 3.1)
+  rubocop (= 0.17.0)
+  sensu-plugins-sidekiq!
+  yard (~> 0.8)

--- a/README.md
+++ b/README.md
@@ -8,11 +8,29 @@
 
 ## Functionality
 
+Check varius metrics and checks for Sidekiq. Requires [sidekiq-monitor-stats](https://github.com/harvesthq/sidekiq-monitor-stats)
+running on your application. Pass the `--url URL` option with the url to your monitor stats. Both scripts also accept a
+`--auth USER:PASSWORD` option in case the monitor stats url sits behind basic authorization.
+
+### check-sidekiq.rb
+
+Uses the maximum latency to figure out when to raise warnings. The latency is the time a job has been waiting in the queue (without
+being processed). It's generally a good metric to know when there's trouble with Sidekiq. There are some options you can pass to this
+script:
+
+* `--warn SECONDS`: Warn after job has been SECONDS seconds in a queue. The default is 120.
+* `--crit SECONDS`: Critical after job has been SECONDS seconds in a queue. The default is 300.
+
+### sidekiq-metrics.rb
+
+Generates total concurrency (`concurrency`), total busy (`busy`) and maximum latency (`latency`) metrics for your sidekiq. A graph of
+busy vs. concurrency is specially useful for capacity planning. The latency metric should let you know if something is wrong (or there
+are spikes that don't trigger a warning or a critical). Accepts an `--scheme SCHEME` option to know what scheme to append to the
+metrics (the default is `sidekiq`).
+
 ## Files
- *
- *
- *
- *
+ * bin/check-sidekiq.rb
+ * bin/sidekiq-metris.rb
 
 ## Usage
 
@@ -52,5 +70,3 @@ gem_package 'sensu-plugins-sidekiq' do
   version '0.0.1'
 end
 ```
-
-## Notes

--- a/bin/check-sidekiq.rb
+++ b/bin/check-sidekiq.rb
@@ -1,0 +1,89 @@
+#! /usr/bin/env ruby
+# encoding: UTF-8
+#   check-sidekiq
+#
+# DESCRIPTION:
+#   Check sidekiq status from a sidekiq-monitor-stats enabled endpoint.
+#
+#     https://github.com/harvesthq/sidekiq-monitor-stats
+#
+#   Uses the maximum latency to check the status.
+#
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#   gem: open-uri
+#   gem: json
+#
+# LICENSE:
+#   Albert Llop albert@getharvest.com
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'rubygems' if RUBY_VERSION < '1.9.0'
+
+require 'sensu-plugin/check/cli'
+require 'open-uri'
+require 'json'
+
+class SidekiqCheck < Sensu::Plugin::Check::CLI
+  option :url,
+         short: '-u URL',
+         long: '--url URL',
+         description: 'Url to query',
+         required: true
+
+  option :auth,
+         short: '-a USER:PASSWORD',
+         long: '--auth USER:PASSWORD',
+         description: 'Basic auth credentials if you need them',
+         proc: proc { |auth| auth.split(':') }
+
+  option :warn,
+         short: '-w SECONDS',
+         long: '--warn SECONDS',
+         description: 'Warn after job has been SECONDS seconds in a queue',
+         proc: proc { |seconds| seconds.to_i },
+         default: 120
+
+  option :crit,
+         short: '-c SECONDS',
+         long: '--crit SECONDS',
+         description: 'Critical after job has been SECONDS seconds in a queue',
+         proc: proc { |seconds| seconds.to_i },
+         default: 300
+
+  def run
+    begin
+      stats = JSON.parse(
+        if config[:auth]
+          open(config[:url], http_basic_authentication: config[:auth]).read
+        else
+          open(config[:url]).read
+        end
+      )
+
+    rescue => error
+      unknown "Could not load Sidekiq stats from #{config[:url]}. Error: #{error}"
+    end
+
+    maximum_latency   = stats['queues'].map { |name, data| data['latency'] }.max
+    total_concurrency = stats['processes'].map { |process| process['concurrency'] }.reduce(&:+) || 0
+
+    if total_concurrency.zero?
+      critical 'There are no Sidekiq workers'
+    end
+
+    if maximum_latency > config[:warn]
+      warning "A job has been in a queue longer than #{config[:warn]} seconds"
+    elsif maximum_latency > config[:crit]
+      critical "A job has been in a queue longer than #{config[:crit]} seconds"
+    end
+
+    ok "Maximum job latency #{maximum_latency}"
+  end
+end

--- a/bin/check-sidekiq.rb
+++ b/bin/check-sidekiq.rb
@@ -1,5 +1,12 @@
 #! /usr/bin/env ruby
 # encoding: UTF-8
+
+require 'rubygems' if RUBY_VERSION < '1.9.0'
+
+require 'sensu-plugin/check/cli'
+require 'open-uri'
+require 'json'
+
 #   check-sidekiq
 #
 # DESCRIPTION:
@@ -23,13 +30,6 @@
 #   Released under the same terms as Sensu (the MIT license); see LICENSE
 #   for details.
 #
-
-require 'rubygems' if RUBY_VERSION < '1.9.0'
-
-require 'sensu-plugin/check/cli'
-require 'open-uri'
-require 'json'
-
 class SidekiqCheck < Sensu::Plugin::Check::CLI
   option :url,
          short: '-u URL',

--- a/bin/sidekiq-metrics.rb
+++ b/bin/sidekiq-metrics.rb
@@ -1,0 +1,76 @@
+#! /usr/bin/env ruby
+# encoding: UTF-8
+#   sidekiq-metrics
+#
+# DESCRIPTION:
+#   Pull sidekiq metrics from a sidekiq-monitor-stats enabled endpoint.
+#
+#     https://github.com/harvesthq/sidekiq-monitor-stats
+#
+# OUTPUT:
+#   metric data
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#   gem: open-uri
+#   gem: json
+#
+# LICENSE:
+#   Albert Llop albert@getharvest.com
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'rubygems' if RUBY_VERSION < '1.9.0'
+
+require 'sensu-plugin/metric/cli'
+require 'open-uri'
+require 'json'
+
+class SidekiqMetrics < Sensu::Plugin::Metric::CLI::Graphite
+  option :url,
+         short: '-u URL',
+         long: '--url URL',
+         description: 'Url to query',
+         required: true
+
+  option :auth,
+         short: '-a USER:PASSWORD',
+         long: '--auth USER:PASSWORD',
+         description: 'Basic auth credentials if you need them',
+         proc: proc { |auth| auth.split(':') }
+
+  option :scheme,
+         description: 'Metric naming scheme, text to prepend to metric',
+         short: '-s SCHEME',
+         long: '--scheme SCHEME',
+         default: 'sidekiq'
+
+  def run
+    begin
+      stats = JSON.parse(
+        if config[:auth]
+          open(config[:url], http_basic_authentication: config[:auth]).read
+        else
+          open(config[:url]).read
+        end
+      )
+
+    rescue => error
+      unknown "Could not load sidekiq stats from #{config[:url]}. Error: #{error}"
+    end
+
+    total_concurrency = stats['processes'].map { |process| process['concurrency'] }.reduce(&:+) || 0
+    total_busy        = stats['processes'].map { |process| process['busy'] }.reduce(&:+) || 0
+    maximum_latency   = stats['queues'].map { |name, data| data['latency'] }.max
+
+    output "#{config[:scheme]}.concurrency", total_concurrency
+    output "#{config[:scheme]}.busy",        total_busy
+    output "#{config[:scheme]}.latency",     maximum_latency
+
+    ok
+  end
+end

--- a/bin/sidekiq-metrics.rb
+++ b/bin/sidekiq-metrics.rb
@@ -1,5 +1,12 @@
 #! /usr/bin/env ruby
 # encoding: UTF-8
+
+require 'rubygems' if RUBY_VERSION < '1.9.0'
+
+require 'sensu-plugin/metric/cli'
+require 'open-uri'
+require 'json'
+
 #   sidekiq-metrics
 #
 # DESCRIPTION:
@@ -23,13 +30,6 @@
 #   Released under the same terms as Sensu (the MIT license); see LICENSE
 #   for details.
 #
-
-require 'rubygems' if RUBY_VERSION < '1.9.0'
-
-require 'sensu-plugin/metric/cli'
-require 'open-uri'
-require 'json'
-
 class SidekiqMetrics < Sensu::Plugin::Metric::CLI::Graphite
   option :url,
          short: '-u URL',

--- a/sensu-plugins-sidekiq.gemspec
+++ b/sensu-plugins-sidekiq.gemspec
@@ -32,26 +32,26 @@ Gem::Specification.new do |s|
   s.signing_key            = File.expand_path(pvt_key) if $PROGRAM_NAME =~ /gem\z/
   s.summary                = ''
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
-  s.version                = SensuPluginsSidekiq::Version::VER_STRING
+  s.version                = SensuPluginsSidekiq::VERSION
 
   s.add_runtime_dependency 'sensu-plugin', '1.1.0'
-  
+
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
-  
+
   s.add_development_dependency 'rubocop', '0.17.0'
-  
+
   s.add_development_dependency 'rspec', '~> 3.1'
-  
+
   s.add_development_dependency 'bundler', '~> 1.7'
-  
+
   s.add_development_dependency 'rake', '~> 10.0'
-  
+
   s.add_development_dependency 'github-markup', '~> 1.3'
-  
+
   s.add_development_dependency 'redcarpet', '~> 3.2'
-  
+
   s.add_development_dependency 'yard', '~> 0.8'
-  
+
   s.add_development_dependency 'pry', '~> 0.10'
-  
+
 end


### PR DESCRIPTION
@mattyjones as you asked in https://github.com/sensu/sensu-community-plugins/pull/1133. I have a couple comments:
- I didn't know there was a new organization for this. I had to use github search to know what you meant by `sensu-plugins-sidekiq`. I think other contributors would appreciate knowing that. Maybe a note in the `sensu-community-plugins` README would help too.
- The repo couldn't run `bundle install` as it was, hence the https://github.com/sensu-plugins/sensu-plugins-sidekiq/commit/ed99ffce7789a4be639f819026b5170b6d71ce7e. I see other repos have a [specific `version.rb`](https://github.com/sensu-plugins/sensu-plugins-github/blob/master/lib/sensu-plugins-github/version.rb). Would you rather I copy that file to this repo?
- There's no testing yet, but I'd be happy to add some test coverage to it! Do you have any example where a sensu plugin is tested?

Cheers!
